### PR TITLE
FactoryGirlのtraitのスコープが間違っていたので修正

### DIFF
--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -3,9 +3,9 @@ FactoryGirl.define do
     body 'Body'
 
     entry
-  end
 
-  trait :approved do
-    status 'approved'
+    trait :approved do
+      status 'approved'
+    end
   end
 end


### PR DESCRIPTION
# 動作確認

``` bash
[2] pry(main)> FactoryGirl.build(:blog, :approved)
ArgumentError: Trait not registered: approved
from /usr/local/bundle/gems/factory_girl-4.7.0/lib/factory_girl/registry.rb:24:in `find'
[3] pry(main)> FactoryGirl.build(:comment, :approved)
   (0.3ms)  BEGIN
  SQL (0.6ms)  INSERT INTO `blogs` (`title`, `created_at`, `updated_at`) VALUES ('Title', '2016-06-14 05:09:23', '2016-06-14 05:09:23')
   (3.3ms)  COMMIT
   (0.3ms)  BEGIN
  SQL (0.5ms)  INSERT INTO `entries` (`title`, `body`, `blog_id`, `created_at`, `updated_at`) VALUES ('Title', 'Body', 8, '2016-06-14 05:09:23', '2016-06-14 05:09:23')
   (2.3ms)  COMMIT
+----+------+----------+----------+------------+------------+
| id | body | status   | entry_id | created_at | updated_at |
+----+------+----------+----------+------------+------------+
|    | Body | approved | 8        |            |            |
+----+------+----------+----------+------------+------------+
1 row in set
```
