### PR TITLE
Add heroku deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,4 @@ RUN bundle install
 COPY . /usr/src/app
 
 EXPOSE 3000
-CMD ["./bin/rails", "server", "-b", "0.0.0.0"]
-
+CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,10 @@ group :test do
   gem 'simplecov', require: false
   gem 'codeclimate-test-reporter', require: false
 end
+
+# https://devcenter.heroku.com/articles/getting-started-with-rails4
+gem 'puma'
+group :production do
+  gem 'rails_12factor'
+end
+ruby '2.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ GEM
     pry-stack_explorer (0.4.9.2)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
+    puma (3.4.0)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -164,6 +165,11 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (4.2.6)
       actionpack (= 4.2.6)
       activesupport (= 4.2.6)
@@ -268,7 +274,9 @@ DEPENDENCIES
   pry-doc
   pry-rails
   pry-stack_explorer
+  puma
   rails (= 4.2.6)
+  rails_12factor
   rspec
   rspec-rails
   sass-rails (~> 5.0)
@@ -279,6 +287,9 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+RUBY VERSION
+   ruby 2.3.1p112
 
 BUNDLED WITH
    1.12.5

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,15 @@
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'
+
+on_worker_boot do
+  # Worker specific setup for Rails 4.1+
+  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
+  ActiveRecord::Base.establish_connection
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - mailcatcher
     build: .
     command:
-      [ "bash", "-c", "rm -f tmp/pids/server.pid; ./bin/rails server -b 0.0.0.0" ]
+      [ "bash", "-c", "rm -f tmp/pids/server.pid; bundle exec puma -C config/puma.rb" ]
     mem_limit: 384m
     environment:
       DISABLE_SPRING: "1"

--- a/rails-practice.iml
+++ b/rails-practice.iml
@@ -79,12 +79,16 @@
     <orderEntry type="library" scope="PROVIDED" name="pry-doc (v0.8.0, rbenv: 2.3.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="pry-rails (v0.3.4, rbenv: 2.3.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="pry-stack_explorer (v0.4.9.2, rbenv: 2.3.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="puma (v3.4.0, rbenv: 2.3.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rack (v1.6.4, rbenv: 2.3.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rack-test (v0.6.3, rbenv: 2.3.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rails (v4.2.6, rbenv: 2.3.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rails-deprecated_sanitizer (v1.0.3, rbenv: 2.3.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rails-dom-testing (v1.0.7, rbenv: 2.3.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rails-html-sanitizer (v1.0.3, rbenv: 2.3.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rails_12factor (v0.0.3, rbenv: 2.3.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rails_serve_static_assets (v0.0.5, rbenv: 2.3.1) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rails_stdout_logging (v0.0.5, rbenv: 2.3.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="railties (v4.2.6, rbenv: 2.3.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rake (v11.1.2, rbenv: 2.3.1) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rdoc (v4.2.2, rbenv: 2.3.1) [gem]" level="application" />

--- a/wercker.yml
+++ b/wercker.yml
@@ -44,3 +44,16 @@ build:
       - script:
           name: rspec
           code: bundle exec rspec
+
+deploy:
+    steps:
+      - heroku-deploy:
+          install-toolbelt: true
+          key: $HEROKU_KEY
+          key-name: HEROKU_KEY_PAIR
+          user: $HEROKU_USER
+          app-name: $HEROKU_APP_NAME
+      - script:
+          name: Update database
+          code: heroku run rake db:migrate --app $HEROKU_APP_NAME
+


### PR DESCRIPTION
- [x] [Getting Started with Rails 4.x on Heroku](https://devcenter.heroku.com/articles/getting-started-with-rails4)の設定を追加
- [x] ClearDBアドオン追加、utf8mb4使えるようにする

``` bash
% heroku addons:create cleardb:ignite
% heroku config:set DATABASE_URL='mysql2://[user]:[pass]@[host].cleardb.net/[db]?reconnect=true&encoding=utf8mb4&collation=utf8mb4_general_ci'
# databaseをutf8mb4で作り直す
% heroku run rake db:migrate:reset
```
- [x] RailsのRackをHeroku推奨のpumaに変更
- [x] werckerのdeploy用pipelineを追加
  - 参考: http://uchinoinu.hatenablog.jp/entry/2016/06/15/090431
    ![image](https://cloud.githubusercontent.com/assets/1984449/16214050/42cc2bbc-378f-11e6-8e69-8d54bcfe1833.png)
