### PR TITLE
setting for Heroku Addons - SendGrid

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
   # Enable Rack::Cache to put a simple HTTP cache in front of your application
@@ -76,4 +76,16 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Setting for Heroku Addons - SendGrid
+  config.action_mailer.default_url_options = {host: ENV['APP_HOSTNAME']}
+  config.action_mailer.smtp_settings = {
+      :address => 'smtp.sendgrid.net',
+      :port => '587',
+      :authentication => :plain,
+      :user_name => ENV['SENDGRID_USERNAME'],
+      :password => ENV['SENDGRID_PASSWORD'],
+      :domain => 'heroku.com',
+      :enable_starttls_auto => true
+  }
 end


### PR DESCRIPTION
- [x] HerokuからSendGridのSMTP APIを利用するための設定

``` bash
heroku addons:add sendgrid:starter
heroku config:set APP_HOSTNAME='[app name].herokuapp.com'
```
